### PR TITLE
Updating master-main references, and medic-release-testing to cht-release-testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 As functionality is added to the app we should be adding release tests to ensure we haven't regressed. 
 
-* Add a new Issue to the [medic-release-testing](https://github.com/medic/medic-release-testing/issues) repo in github. 
+* Add a new Issue to the [cht-release-testing](https://github.com/medic/cht-release-testing/issues) repo in github. 
 * Add a title that describes what is being tested, on which config, with which type of user.
 * For the description add which type of user, the type of config, which platform(desktop, mobile app), the steps to test and the expected result. 
 * Close the issue. 
@@ -22,11 +22,11 @@ Run `node create_release_project.js --version <release_vers>` to create a new pr
 
 EX: `node create_release_project.js --version 3.3.0`
 
-This will generate a project in medic-release-testing repo. Once completed you should see the link to the project in the console. 
+This will generate a project in cht-release-testing repo. Once completed you should see the link to the project in the console. 
 
-EX: Project created at: https://github.com/medic/medic-release-testing/projects/27
+EX: Project created at: https://github.com/medic/cht-release-testing/projects/27
 
-To generate a project with specific test cases (eg for minor releases and patches), add a new label to the issues you need to test and modify labels in [config.js](https://github.com/medic/medic-release-testing/blob/master/config.js#L36) to use the new label.
+To generate a project with specific test cases (eg for minor releases and patches), add a new label to the issues you need to test and modify labels in [config.js](https://github.com/medic/cht-release-testing/blob/main/config.js#L36) to use the new label.
 
 ## Executing Test Cases
 

--- a/config.js
+++ b/config.js
@@ -31,7 +31,7 @@ function getToken() {
 }
 
 module.exports = {
-  repoName: 'medic-release-testing',
+  repoName: 'cht-release-testing',
   owner: 'medic',
   labels: 'Release Test',
   excludeLabels: ['automated','no automation','retired config'],

--- a/ide_config/vscode/vscode.md
+++ b/ide_config/vscode/vscode.md
@@ -3,7 +3,7 @@
 1. This assumes you have gone through the [development](https://github.com/medic/cht-core/blob/master/DEVELOPMENT.md) setup guide. 
 1. Open a terminal to cht-core repo.
 1. Create a symlink to the vscode folder here to your cht-core repo. This will allow us to use git to manage any potential changes we need to share in this repo.
-    EX:  `ln -s /home/user_name/dev/medic-release-testing/ide_config/vscode/ /home/user_name/dev/cht-core/.vscode`
+    EX:  `ln -s /home/user_name/dev/cht-release-testing/ide_config/vscode/ /home/user_name/dev/cht-core/.vscode`
 
 1. Click the debug icon on the left tool bar.
 1. Select launch e2e


### PR DESCRIPTION
This pull request is part of the changes for ticket https://github.com/medic/cht-core/issues/6574. With this, we are addressing the changes needed for the https://github.com/medic/cht-release-testing repo.

However, we are also addressing another issue, and that is to remove references to medic-release-testing and use cht-release-testing (to avoid 301s)

In order to try to reduce the downtime as much as possible without needing to do a lot of extra work, these are the steps to do to update the default branch name.

- [x] Have this pull request reviewed and approved
- [x] Once approved, but before merging it, change the default branch name to main and remove master (manually, via GH). This could cause processes like CI to break for a short time since they could be referencing master.
- [x] Merge the pull request. As the main branch is now being referenced, and the branch started to exist since the previous step, any broken steps/CI should be fixed after this.